### PR TITLE
Add opacity options

### DIFF
--- a/appearance/textures.py
+++ b/appearance/textures.py
@@ -70,7 +70,10 @@ def apply_material(obj, col, shading=None, recursive=False, type_req=None, inten
                 obj.active_material = material
             else:
                 obj.active_material = shade_material(material, shading)
-
+                
+            if "opacity" in kwargs:
+                obj.active_material.diffuse_color[3] =  kwargs['opacity']
+                
             if 'brighter' in kwargs:
                 brighter = kwargs['brighter']
             else:


### PR DESCRIPTION
To set the opacity for a Bobject, you can modify the code in penrose2.py. For example, you can change the faces attribute as follows:

faces = [
    Polygon(
        vertices=[Vector(v) for v in ch.points[list(indices)]],
        color='joker',
        transmission=0.5,
        opacity=0.5
    )
]
By setting the opacity parameter to 0.5, the faces of the Bobject will be rendered with 50% opacity.